### PR TITLE
Implement getKey function

### DIFF
--- a/module.json
+++ b/module.json
@@ -3,9 +3,9 @@
   "title": "Hex Token Size Support",
   "description": "Improves support for hexagonal tokens of sizes greater than one by altering the grid snapping rules",
   "author": "Ourobor",
-  "version": "1.1.0",
-  "minimumCoreVersion": "0.8.6",
-  "compatibleCoreVersion": "0.8.6",
+  "version": "1.1.1",
+  "minimumCoreVersion": "9.238",
+  "compatibleCoreVersion": "9.240",
   "esmodules": [
     "modules/hooks.js",
     "modules/ruler-changes.js",
@@ -13,6 +13,6 @@
     "modules/token-changes.js"
   ],
   "url": "https://github.com/Ourobor/Hex-Size-Support",
-  "manifest": "https://raw.githubusercontent.com/Ourobor/Hex-Size-Support/1.1.0/module.json",
-  "download": "https://github.com/Ourobor/Hex-Size-Support/archive/refs/tags/1.1.0.zip"
+  "manifest": "https://raw.githubusercontent.com/Ourobor/Hex-Size-Support/1.1.1/module.json",
+  "download": "https://github.com/Ourobor/Hex-Size-Support/archive/refs/tags/1.1.1.zip"
 }

--- a/modules/helpers.js
+++ b/modules/helpers.js
@@ -173,6 +173,15 @@ function calculateSnapPointsCols(x,y,h,w,xOff, yOff){
     return {x: snapX, y: snapY}
 }
 
+export function getKey(event) {
+    if ( event.code === "Space" ) return event.code;
+    if ( /^Digit/.test(event.code) ) return event.code[5];
+    if ( (event.location === 3) && ((event.code in game.keyboard.moveKeys) || (event.code in game.keyboard.zoomKeys)) ) {
+        return event.code;
+    }
+    return event.key;
+}
+
 //##############################################################
 //#############Deprecated#######################################
 //##############################################################

--- a/modules/hex-token-config.js
+++ b/modules/hex-token-config.js
@@ -1,3 +1,4 @@
+import { getKey } from './helpers.js'
 
 export class HexTokenConfig extends FormApplication {
 
@@ -168,7 +169,7 @@ export class HexTokenConfig extends FormApplication {
 
 
   _onKeyDown(event) {
-    const key = game.keyboard.getKey(event);
+    const key = getKey(event);
     if ( !(key in game.keyboard.moveKeys) || game.keyboard.hasFocus ) return;
     event.preventDefault();
 

--- a/modules/hooks.js
+++ b/modules/hooks.js
@@ -1,14 +1,5 @@
 import { HexTokenConfig } from './hex-token-config.js'
-import { findVertexSnapPoint, findMovementToken, getEvenSnappingFlag, getAltSnappingFlag, getAltOrientationFlag, getCenterOffset } from './helpers.js'
-
-export function getKey(event) {
-    if ( event.code === "Space" ) return event.code;
-    if ( /^Digit/.test(event.code) ) return event.code[5];
-    if ( (event.location === 3) && ((event.code in game.keyboard.moveKeys) || (event.code in game.keyboard.zoomKeys)) ) {
-        return event.code;
-    }
-    return event.key;
-}
+import { findVertexSnapPoint, findMovementToken, getEvenSnappingFlag, getAltSnappingFlag, getAltOrientationFlag, getCenterOffset, getKey } from './helpers.js'
 
 //load in the hex token config's html template
 Hooks.once('init', async function(){

--- a/modules/hooks.js
+++ b/modules/hooks.js
@@ -1,6 +1,15 @@
 import { HexTokenConfig } from './hex-token-config.js'
 import { findVertexSnapPoint, findMovementToken, getEvenSnappingFlag, getAltSnappingFlag, getAltOrientationFlag, getCenterOffset } from './helpers.js'
 
+export function getKey(event) {
+    if ( event.code === "Space" ) return event.code;
+    if ( /^Digit/.test(event.code) ) return event.code[5];
+    if ( (event.location === 3) && ((event.code in game.keyboard.moveKeys) || (event.code in game.keyboard.zoomKeys)) ) {
+        return event.code;
+    }
+    return event.key;
+}
+
 //load in the hex token config's html template
 Hooks.once('init', async function(){
 	loadTemplates(['modules/hex-size-support/templates/hex-token-config.html'])
@@ -36,7 +45,7 @@ Hooks.once("ready", async function(){
 
 
     document.addEventListener("keydown", function(event){
-        const key = game.keyboard.getKey(event);
+        const key = getKey(event);
         if(event.shiftKey){
             if(key == "R" || key == "r"){
                 let tokens = canvas.tokens.placeables.filter(o => o._controlled); 


### PR DESCRIPTION
This function was removed in Foundry VTT v9. This reimplementation is sourced from [fvtt-pointer's keybindings.js](https://github.com/Moerill/fvtt-pointer/pull/31/commits/1cb11379b78da80e820356bc77d5a454822ccb82).